### PR TITLE
fix parser property position for eslintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,8 +4,8 @@ module.exports = {
     browser: true,
     node: true
   },
+  parser: 'babel-eslint',
   parserOptions: {
-    parser: 'babel-eslint',
     sourceType: 'module',
     ecmaVersion: 2019
   },


### PR DESCRIPTION
The 'parser' property must be in parallel with the 'parserOptions' property.

Refer to the README for babel-eslint setting.
https://github.com/babel/babel-eslint#additional-parser-configuration